### PR TITLE
Use Python 3.7 compatible dependencies and flask-session fix

### DIFF
--- a/confidant/app.py
+++ b/confidant/app.py
@@ -24,7 +24,7 @@ if app.config['SSLIFY']:
 
 if app.config.get('REDIS_URL'):
     import redis
-    from flask.ext.session import Session
+    from flask_session import Session
     app.config['SESSION_REDIS'] = redis.Redis.from_url(
         app.config['REDIS_URL']
     )

--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -79,9 +79,9 @@
                 $scope.shown = true;
             }
 
-	    $scope.groups = function(usergroups) {
-		return [""].concat(usergroups);
-	    }
+            $scope.groups = function(usergroups) {
+                return [""].concat(usergroups);
+            }
 
             $scope.showValue = function(credentialPair) {
                 if (credentialPair.shown) {

--- a/requirements.in
+++ b/requirements.in
@@ -48,7 +48,7 @@ cffi>1.10.0
 # License: BSD
 # Upstream url: https://github.com/fengsp/flask-session
 # Use: For shared sessions
-Flask-Session==0.2.1
+Flask-Session==0.2.3
 
 # Redis
 # License: MIT

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ entrypoints==0.3          # via flake8
 enum34==1.1.6
 flake8==3.7.8
 flask-script==2.0.5
-flask-session==0.2.1
+flask-session==0.2.3
 flask-sslify==0.1.5
 flask==1.1.1
 funcsigs==1.0.2           # via mock

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -16,11 +16,11 @@ docutils==0.15.2          # via botocore
 entrypoints==0.3          # via flake8
 flake8==3.7.8
 flask-script==2.0.5
-flask-session==0.2.1
+flask-session==0.2.3
 flask-sslify==0.1.5
 flask==1.1.1
-gevent==1.2.1
-greenlet==0.4.12
+gevent==1.4.0             # force this version for py3.7
+greenlet==0.4.15          # force this version for py3.7
 guard==1.0.1
 gunicorn==19.9.0
 idna==2.8                 # via requests


### PR DESCRIPTION
Fixing two things for our environment:
- Python 3.7 compatible dependencies (gevent, greenlet and flask-session)
- Fixing flask_session import

r? @elewis-stripe 