### PR TITLE
Python 3 fix for bootstrap script: decode bytestreams to utf-8

### DIFF
--- a/confidant/scripts/bootstrap.py
+++ b/confidant/scripts/bootstrap.py
@@ -35,8 +35,10 @@ class GenerateSecretsBootstrap(Command):
         )
         f = Fernet(data_key['plaintext'])
         data = {
-            'data_key': base64.b64encode(data_key['ciphertext']),
-            'secrets': f.encrypt(secrets.encode('utf-8'))
+            'data_key': base64.b64encode(
+                data_key['ciphertext']
+            ).decode('utf-8'),
+            'secrets': f.encrypt(secrets.encode('utf-8')).decode('utf-8')
         }
         data = json.dumps(data)
         if _out == '-':


### PR DESCRIPTION
Correct bootstrap.py handling of bytestreams.

This is a partial port of the commit found on lyft's master: https://github.com/lyft/confidant/commit/2ea600f6d07bd1121f0a2a576460e9b6355d26d2

The gist is that python 3 won't automatically cast a stream of bytes to a string, which prevents json.dumps from functioning. This diff corrects that behavior.

r? @elewis-stripe
cc? @apakulov-stripe @jamesbvaughan-stripe 